### PR TITLE
test: Add Go quicksort with intentionally poor formatting

### DIFF
--- a/temp/go.mod
+++ b/temp/go.mod
@@ -1,0 +1,3 @@
+module example.com/temp
+
+go 1.25.4

--- a/temp/main.go
+++ b/temp/main.go
@@ -1,0 +1,33 @@
+package main
+
+import "fmt"
+
+func main(){
+fmt.Println("Quick Sort Example")
+arr:=[]int{64,34,25,12,22,11,90}
+fmt.Println("Original array:",arr)
+quickSort(arr,0,len(arr)-1)
+fmt.Println("Sorted array:",arr)
+}
+
+// quickSort function with intentionally poor formatting
+func quickSort(arr []int,low int,high int){
+if low<high{
+pi:=partition(arr,low,high)
+quickSort(arr,low,pi-1)
+quickSort(arr,pi+1,high)
+}
+}
+
+func partition(arr []int,low int,high int)int{
+pivot:=arr[high]
+i:=low-1
+for j:=low;j<high;j++{
+if arr[j]<pivot{
+i++
+arr[i],arr[j]=arr[j],arr[i]
+}
+}
+arr[i+1],arr[high]=arr[high],arr[i+1]
+return i+1
+}


### PR DESCRIPTION
Requested by @minorcell

This PR adds a temporary Go project to test hook functionality.

## Summary
- Created `temp/` directory with a basic Go module
- Added `go.mod` and `main.go`
- Implemented a quicksort function with **intentionally poor formatting** to violate `go fmt` standards
- This is for testing git hooks or linting hooks

## Formatting Violations
The `main.go` file intentionally includes:
- Missing spaces after keywords (e.g., `func main(){`)
- Missing spaces around operators (`:=`, `<`, `>`, etc.)
- Improper spacing in function declarations
- Inconsistent formatting throughout

Fixes #44