### PR TITLE
test: add temp Go project with intentionally bad formatting

### DIFF
--- a/temp/go.mod
+++ b/temp/go.mod
@@ -1,0 +1,3 @@
+module temp
+
+go 1.21

--- a/temp/main.go
+++ b/temp/main.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+
+func main() {
+	arr := []int{64, 34, 25, 12, 22, 11, 90}
+	fmt.Println("Original array:", arr)
+	quickSort(arr, 0, len(arr)-1)
+	fmt.Println("Sorted array:", arr)
+}
+
+// quickSort implements the quicksort algorithm with intentionally bad formatting
+func quickSort(arr []int, low int, high int){
+if low<high{
+pivotIndex:=partition(arr,low,high)
+quickSort(arr,low,pivotIndex-1)
+quickSort(arr,pivotIndex+1,high)}}
+
+func partition(arr []int,low int,high int)int{
+pivot:=arr[high]
+i:=low-1
+for j:=low;j<high;j++{
+if arr[j]<pivot{
+i++
+arr[i],arr[j]=arr[j],arr[i]}}
+arr[i+1],arr[high]=arr[high],arr[i+1]
+return i+1}


### PR DESCRIPTION
Requested by @minorcell

This PR adds a temporary Go project for testing hook triggers.

### Summary
- Created `temp/` directory with a simple Go module
- Added `go.mod` and `main.go` files
- Implemented a quicksort function with intentionally bad formatting (violates `go fmt` style)
- The code deliberately violates Go formatting standards including:
  - Missing spaces around operators
  - Incorrect brace placement
  - Missing newlines between statements
  - Poor indentation

This is for testing purposes to trigger formatting hooks.

Closes #46

Generated with [codeagent](https://github.com/qbox/codeagent)
Co-authored-by: minorcell <120795714+minorcell@users.noreply.github.com>