### PR TITLE
docs(www): 对齐产品宣传与实际能力，新增安装路径

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -83,7 +83,7 @@
           </h1>
           <p class="hero-subtitle">
             轻量级浏览器扩展，助您快速捕捉网页中的文字、图片与链接。<br />
-            所有数据仅存储在本地，保护您的隐私与创作灵感。
+            数据仅存于本地 IndexedDB，不上传服务器，隐私可控。
           </p>
           <div class="hero-actions">
             <a href="#download" class="btn btn-primary">
@@ -187,7 +187,7 @@
             </p>
             <div class="feature-highlight">
               <span>✓ 自动提取上下文</span>
-              <span>✓ 智能去重</span>
+              <span>✓ 智能去重（同页相同内容不重复）</span>
             </div>
           </div>
 
@@ -227,7 +227,7 @@
             </p>
             <div class="feature-highlight">
               <span>✓ 快速访问</span>
-              <span>✓ 组织整理</span>
+              <span>✓ 可回到原文上下文</span>
             </div>
           </div>
 
@@ -263,8 +263,8 @@
             </div>
             <h3 class="feature-title">导出分享</h3>
             <p class="feature-description">
-              支持导出为精美图片卡片和 Markdown
-              文档，轻松分享您的灵感收藏，或用于创作参考。
+              支持导出为精美图片卡片与 ZIP（Markdown 文档 + 图片），
+              便于归档与二次创作。
             </p>
             <div class="feature-highlight">
               <span>✓ 图片卡片导出</span>
@@ -321,7 +321,8 @@
             <div class="step-content">
               <h3 class="step-title">选中心仪内容</h3>
               <p class="step-description">
-                在网页中选中想要收藏的文本、图片或链接，右键点击"拾句"菜单。
+                在网页中选中想要收藏的文本、图片或链接，
+                使用右键菜单「拾句」或快捷键 <code>Ctrl + Shift + S</code> 触发保存。
               </p>
             </div>
           </div>
@@ -386,6 +387,13 @@
                 </svg>
                 Chrome 应用商店（即将上线）
               </a>
+              <a href="https://github.com/minorcell/pick-quote" target="_blank" rel="noopener" class="btn btn-outline btn-large">
+                <svg viewBox="0 0 24 24" width="22" height="22">
+                  <path fill="currentColor" d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z" />
+                </svg>
+                从源码安装（开发者）
+              </a>
+              <p class="download-note">或查看 README 了解手动安装与打包</p>
               <p class="download-note">或下载安装包手动安装</p>
             </div>
           </div>
@@ -447,7 +455,7 @@
           <div class="footer-brand">
             <span class="footer-title">拾句</span>
             <p class="footer-desc">
-              轻量级浏览器扩展，让灵感收集变得简单而优雅。
+              轻量级浏览器扩展，让灵感收集变得简单而优雅。开源、无广告、最小权限。
             </p>
           </div>
           <a


### PR DESCRIPTION
Requested by @minorcell

本 PR 将官网宣传与实际产品能力对齐，并补充安装路径：

## 变更摘要
- 强化隐私与本地存储表述：明确“仅存本地 IndexedDB，不上传服务器”
- 补充触发方式：在使用流程中加入“右键菜单 + 快捷键 Ctrl+Shift+S”
- 明确导出能力：文案指向“ZIP（Markdown+图片）”与“图片卡片导出”
- 下载区增加“从源码安装（开发者）”按钮，指向仓库主页/README
- 页脚补充“开源、无广告、最小权限”

## 背景
根据 README 与 CLAUDE.md，产品具备本地 IndexedDB、去重、上下文/来源记录、导出 ZIP 与图片卡片等能力。官网原文案未涵盖快捷键/右键入口、ZIP 导出细节与 IndexedDB 术语表达，且下载按钮暂无上线链接，存在认知落差。

## 文件影响
- www/index.html（文案更新）

## 后续建议（可选）
- 若近期暂不上线商店，可在 README 增补“打包/手动安装”具体步骤，并在官网链接到该段落
- 如需进一步强调“可回到原文上下文”的溯源能力，可加入一张动效示意图