### PR TITLE
fix: 保留文本格式（换行和段落）

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -191,6 +191,7 @@ export default function ItemCard({
             <Typography
               variant="body2"
               sx={{
+                whiteSpace: "pre-wrap",
                 lineHeight: 1.9,
                 color: "text.primary",
                 pl: 2,

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -108,6 +108,7 @@ const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(
                   textAlign: "justify",
                   textIndent: "2em",
                   wordBreak: "break-word",
+                  whiteSpace: "pre-wrap",
                   fontFamily: "'Noto Serif SC', 'Songti SC', serif"
                 }}>
                 {truncateText(item.content, maxLength)}


### PR DESCRIPTION
Requested by @minorcell

修复 #70：保存的文本内容现在能正确保留原始格式

## 问题描述
之前保存的文本内容会丢失格式，多个段落被压缩成一个段落，换行符也消失了。

## 修复方案
在文本显示组件中添加 CSS 属性 `whiteSpace: "pre-wrap"`，该属性可以：
- 保留文本中的换行符和空格
- 自动换行以适应容器宽度
- 保持原始文本的段落结构

## 修改文件
1. **src/components/ItemCard.tsx** (第194行)
   - 在卡片视图的文本显示中添加 `whiteSpace: "pre-wrap"`
   
2. **src/components/ShareCard.tsx** (第111行)
   - 在分享卡片的文本显示中添加 `whiteSpace: "pre-wrap"`
   - 确保导出的图片也能正确显示格式

## 测试建议
1. 保存一段包含多个段落的文本（使用回车键分段）
2. 在列表视图中查看是否保留了段落分隔
3. 点击查看详情，确认完整格式正确
4. 导出为图片，验证图片中的格式也正确

---

Generated with [codeagent](https://github.com/qbox/codeagent)